### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include LICENSE
 recursive-include mpire/dashboard/static *.eot *.svg *.ttf *.woff *.woff2 *.js *.css
 recursive-include mpire/dashboard/templates *.html
 include requirements.txt


### PR DESCRIPTION
I'm not sure why, but v2.3.0 had the license file in the source distribution but 2.3.1 doesn't. I've added the license file to the `MANIFEST.in` to make sure it's included in future releases.